### PR TITLE
BUG - Fix the invalid_grant error

### DIFF
--- a/lib/omniauth/strategies/runkeeper.rb
+++ b/lib/omniauth/strategies/runkeeper.rb
@@ -35,6 +35,10 @@ module OmniAuth
           { 'userID' => user['userID'] }.merge(profile)
         end
       end
+
+      def query_string
+        '' # The code param shouldn't be sent as part of the callback_url in the callback phase
+      end
     end
   end
 end


### PR DESCRIPTION
When requesting the access token, the exact URL that you supplied when sending the user to the authorization endpoint above should be communicated, without the code parameter.

Overwriting the method query_string prevents that from happening and solves this issue: https://github.com/m4i/omniauth-runkeeper/issues/3
